### PR TITLE
Create arguments table

### DIFF
--- a/templates/lib/params.template.ejs
+++ b/templates/lib/params.template.ejs
@@ -1,6 +1,34 @@
 <% if (doc.params) { %>
 <section class="<%-styles['api-section']-%>">
   <h3>Arguments</h3>
-  * Create params table helper *
+  <table class="<%-styles['variables-matrix']-%> <%-styles['input-arguments']-%>">
+    <thead>
+    <tr>
+      <th>Param</th>
+      <th>Type</th>
+      <th>Details</th>
+    </tr>
+    </thead>
+    <tbody>
+    <% doc.params.forEach(function(param) { %>
+    <tr>
+      <td>
+        <%- param.name -%>
+        <% if(param.alias) { %>| <%- param.alias -%><% } %>
+        <% if(param.optional) { %><div><em>(optional)</em></div><% } %>
+      </td>
+      <td>
+        <% param.typeList.forEach(function(typeName){ %>
+          <a href="" class="<%- typeName -%>"><%- typeName -%></a>
+        <% }); %>
+      </td>
+      <td>
+        <%- param.description -%>
+        <% if(param.defaultValue) { %><p><em>(default: <%- param.defaultValue -%>)</em></p><% } %>
+      </td>
+    </tr>
+    <% }); %>
+    </tbody>
+  </table>
 </section>
 <% } %>


### PR DESCRIPTION
This implementation is valid only for simple `types` of parameters (`String|Function|Object|Array|Boolean`) for more complex `types` (`Array<String>`) we would need another implementation. 

There is an example:

<img width="969" alt="screen shot 2016-07-19 at 4 36 59 pm" src="https://cloud.githubusercontent.com/assets/2417908/16940738/16a92304-4dcf-11e6-8d67-192bcd5288fd.png">
