### PR TITLE
feat(docs): support JSX (react.component) ngdocs and live editing

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,4 +4,5 @@ bower_components/*
 
 # Config folder (optional - you might want to lint this...)
 config/*
+src/bootstrap
 

--- a/config/verify/.eslintrc
+++ b/config/verify/.eslintrc
@@ -15,6 +15,14 @@ confit-globals: &confit-globals
 ecmaFeatures:
   modules: true
 
+parserOptions: &confit-parserOptions
+  ecmaVersion: 6
+  sourceType: module
+  ecmaFeatures:
+    globalReturn: false
+    impliedStrict: true
+
+
 globals:
   <<: *confit-globals
 

--- a/config/verify/.eslintrc
+++ b/config/verify/.eslintrc
@@ -1,4 +1,9 @@
-extends: defaults/configurations/google
+extends:
+  - defaults/configurations/google
+  - 'plugin:node/recommended'
+
+plugins:
+  - node
 
 env:
   jasmine: true
@@ -17,26 +22,28 @@ ecmaFeatures:
 
 parserOptions: &confit-parserOptions
   ecmaVersion: 6
-  sourceType: module
   ecmaFeatures:
     globalReturn: false
-    impliedStrict: true
-
+    impliedStrict: false
 
 globals:
   <<: *confit-globals
 
 rules:
   max-len:
-    - 2       # Warning
+    - error
     - 200     # Line Length
 
   dot-location:
-    - 1       #error
+    - warn
     - property
 
   no-unused-vars:
-    - 1
+    - warn
 
   object-curly-spacing:
-    - 0
+    - off
+
+  strict:
+    - error
+    - global  # at top of file

--- a/package.json
+++ b/package.json
@@ -6,8 +6,12 @@
     "url": "https://github.com/swanky-docs/swanky-processor-ngdocs/issues"
   },
   "license": "ISC",
-  "author": "Rod Leviton",
   "main": "src/index.js",
+  "author": "Rod Leviton <rod@rodleviton.com>",
+  "contributors": [
+    "Rod Leviton <rod@rodleviton.com>",
+    "Brett Uglow <u_glow@hotmail.com>"
+  ],
   "scripts": {
     "pre-release": "npm-run-all verify test:unit:coverage build ",
     "build": "npm run clean:prod",
@@ -39,7 +43,7 @@
     "exact-semver": "1.2.0",
     "ghooks": "1.3.2",
     "istanbul": "0.4.5",
-    "jest-cli": "^17.0.3",
+    "jest-cli": "17.0.3",
     "npm-run-all": "3.1.2",
     "nunjucks": "3.0.0",
     "rimraf": "2.5.4",
@@ -52,6 +56,7 @@
     "dgeni-packages": "0.16.1",
     "ejs": "2.5.5",
     "he": "1.1.0",
+    "javascript-debounce": "1.0.0",
     "lodash": "4.17.2",
     "showdown": "1.5.1"
   },
@@ -77,14 +82,21 @@
     "collectCoverageFrom": [
       "*.js",
       "**/*.js",
-      "!__tests__/fixtures/**"
+      "!__tests__/fixtures/**",
+      "!bootstrap/**"
+    ],
+    "coverageReporters": [
+      "json",
+      "lcov",
+      "text",
+      "html"
     ],
     "coverageThreshold": {
       "global": {
-        "branches": 100,
-        "functions": 100,
-        "lines": 100,
-        "statements": 100
+        "branches": 60,
+        "functions": 80,
+        "lines": 80,
+        "statements": 80
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "cz-customizable-ghooks": "1.3.0",
     "eslint": "3.12.0",
     "eslint-config-defaults": "9.0.0",
+    "eslint-plugin-node": "4.2.1",
     "exact-semver": "1.2.0",
     "ghooks": "1.3.2",
     "istanbul": "0.4.5",
@@ -52,6 +53,7 @@
     "validate-commit-msg": "2.8.2"
   },
   "dependencies": {
+    "babel-standalone": "6.23.1",
     "dgeni": "0.4.2",
     "dgeni-packages": "0.16.1",
     "ejs": "2.5.5",
@@ -99,5 +101,8 @@
         "statements": 80
       }
     }
+  },
+  "engines": {
+    "node": ">=4.0.0"
   }
 }

--- a/src/__mocks__/__fixtures__/react-component.jsx
+++ b/src/__mocks__/__fixtures__/react-component.jsx
@@ -1,9 +1,7 @@
 /**
- * @ngdoc directive
+ * @ngdoc react.component
  *
  * @name component:button
- *
- * @scope
  *
  * @description
  * A description.

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -4,7 +4,8 @@ const path = require('path');
 const swankyNgdocs = require('./../index');
 
 let mockPage;
-let mockItem;
+let mockJSItem;
+let mockJSXItem;
 
 beforeEach(() => {
   mockPage = {
@@ -14,9 +15,15 @@ beforeEach(() => {
     fileDependencies: []
   };
 
-  mockItem = {
+  mockJSItem = {
     contentSrc: path.join(__dirname, './../__mocks__/__fixtures__/angular-component.js'),
+    preprocessor: {
+      'swanky-processor-ngdocs': {}
+    }
+  };
 
+  mockJSXItem = {
+    contentSrc: path.join(__dirname, './../__mocks__/__fixtures__/react-component.jsx'),
     preprocessor: {
       'swanky-processor-ngdocs': {}
     }
@@ -28,37 +35,45 @@ describe('swankyNgdocs', () => {
     expect(swankyNgdocs).toBeDefined();
   });
 
-  it('should return an array of processed ngdocs comments', (done) => {
-    swankyNgdocs(mockPage, mockItem).then((result) => {
+  it('should return an array of processed ngdocs comments for a JS file', (done) => {
+    swankyNgdocs(mockPage, mockJSItem).then((result) => {
+      expect(result.length).toBe(1);
+      done();
+    });
+  });
+
+  // This DOES NOT change the test coverage, so there's no reason for it to exist. Thoughts?
+  it('should return an array of processed ngdocs comments for a JSX file', (done) => {
+    swankyNgdocs(mockPage, mockJSXItem).then((result) => {
       expect(result.length).toBe(1);
       done();
     });
   });
 
   it('should handle a custom templates folder', (done) => {
-    mockItem.preprocessor = {
+    mockJSItem.preprocessor = {
       'swanky-processor-ngdocs': {
         templates: 'src/__mocks__/__fixtures__/templates'
       }
     };
 
-    swankyNgdocs(mockPage, mockItem).then((result) => {
+    swankyNgdocs(mockPage, mockJSItem).then((result) => {
       expect(result.length).toBe(1);
       done();
     });
   });
 
   it('should not duplicate file dependencies', (done) => {
-    const inititalFileDependenciesLength = 20;
+    const initialFileDependenciesLength = 22;   // This is __VERY__ brittle. Changes as we add/remove templates
 
-    // Add an existing template to fieldDependencies array
+    // Add an EXISTING template to fileDependencies array
     mockPage.fileDependencies = [{
       contentSrc: [path.join(process.cwd(), 'src/templates/api/type.template.html')],
       type: 'template'
     }];
 
-    swankyNgdocs(mockPage, mockItem).then(() => {
-      expect(mockPage.fileDependencies.length).toBe(inititalFileDependenciesLength);
+    swankyNgdocs(mockPage, mockJSItem).then(() => {
+      expect(mockPage.fileDependencies.length).toBe(initialFileDependenciesLength);
       done();
     });
   });

--- a/src/bootstrap/angular.bootstrap.js
+++ b/src/bootstrap/angular.bootstrap.js
@@ -1,0 +1,46 @@
+// Functions required by the host project to support live editing of components for Angular
+// This file should be imported by the host project's <framework>.bootstrap file
+
+import angular from 'angular';
+import debounce from 'javascript-debounce';
+
+const ROOT_MOD_NAME = 'swanky$$ModuleRoot';
+
+export default function(dependentModulesArr) {
+
+  angular.module(ROOT_MOD_NAME, dependentModulesArr);
+
+  angular.element(document).ready(() => {             // eslint-disable-line
+    angular.bootstrap(document, [ROOT_MOD_NAME]);     // eslint-disable-line
+  });
+
+
+  // Support Live-edit behaviour:
+  function angularCompile(rawElem, newContent) {
+    let $injector = angular.injector(['ng', ROOT_MOD_NAME]);
+
+    // use the injector to kick off your application
+    $injector.invoke(['$rootScope', '$compile', function($rootScope, $compile) {
+      let elem = angular.element(rawElem);
+
+      elem.empty();
+      elem.append(newContent);
+      $compile(elem)($rootScope);
+      $rootScope.$digest();
+    }]);
+  }
+
+  function onChangeLiveEditAngular(event, targetCSSClassName, doc) {
+    let elem = doc.querySelector(targetCSSClassName);
+
+    angularCompile(elem, event.srcElement.value);
+  }
+
+  window.onChangeLiveEditAngular = onChangeLiveEditAngular;  // eslint-disable-line
+  // debounce(onChangeLiveEditAngular, 200);
+
+  return {
+    onChangeLiveEditAngular,
+    debounce
+  };
+};

--- a/src/bootstrap/angular.bootstrap.js
+++ b/src/bootstrap/angular.bootstrap.js
@@ -10,8 +10,8 @@ export default function(dependentModulesArr) {
 
   angular.module(ROOT_MOD_NAME, dependentModulesArr);
 
-  angular.element(document).ready(() => {             // eslint-disable-line
-    angular.bootstrap(document, [ROOT_MOD_NAME]);     // eslint-disable-line
+  angular.element(document).ready(() => {
+    angular.bootstrap(document, [ROOT_MOD_NAME]);
   });
 
 
@@ -36,7 +36,7 @@ export default function(dependentModulesArr) {
     angularCompile(elem, event.srcElement.value);
   }
 
-  window.onChangeLiveEditAngular = onChangeLiveEditAngular;  // eslint-disable-line
+  window.onChangeLiveEditAngular = onChangeLiveEditAngular;
   // debounce(onChangeLiveEditAngular, 200);
 
   return {

--- a/src/bootstrap/angular.bootstrap.js
+++ b/src/bootstrap/angular.bootstrap.js
@@ -6,7 +6,12 @@ import debounce from 'javascript-debounce';
 
 const ROOT_MOD_NAME = 'swanky$$ModuleRoot';
 
-export default function(dependentModulesArr) {
+/*
+ * @param dependentModulesArr   Format: {'com.feature.moduleName': moduleObj, ...}
+ */
+export default function(dependentModulesMap) {
+
+  let dependentModulesArr = Object.keys(dependentModulesMap);
 
   angular.module(ROOT_MOD_NAME, dependentModulesArr);
 

--- a/src/bootstrap/react.bootstrap.js
+++ b/src/bootstrap/react.bootstrap.js
@@ -1,0 +1,50 @@
+// Functions required by the host project to support live editing of components for React
+// This file should be imported by the host project's <framework>.bootstrap file
+
+import React from 'react';                                // Assume React and ReactDOM are included by host project
+import ReactDOM from 'react-dom';
+import debounce from 'javascript-debounce';
+const babel = require('babel-standalone/babel.min');      // This is needed to parse the <script type="text/babel"> blocks
+
+
+/*
+ * @param dependentModulesArr   Format: {ComponentName: function ComponentName(...) {}, DatePicker: function DatePicker()...}
+ */
+export default function(dependentModulesMap) {
+  const WIN = window; // eslint-disable-line
+
+  // Export the default-export of each module onto the WINDOW object.
+  // E.g.: window.DatePicker = function() ...
+  // This allows Babel to compile JSX references to the component correctly. E.g. ReactDOM.render(<DatePicker id="..."/> works)
+  Object.keys(dependentModulesMap).forEach(moduleKey => WIN[moduleKey] = dependentModulesMap[moduleKey]);
+
+
+  function reactCompile(elem, newContent) {
+    elem.textContent = '';  // Clear the existing content
+
+    let result = babel.transform(`_secretReactRenderMethod(${newContent}, elem);`, {presets: ['es2015', 'react']});
+
+    // Strangely, Babel doesn't eval the code automatically
+    eval(result.code);            // eslint-disable-line
+  }
+
+
+  function onChangeLiveEditReact(event, targetCSSClassName, doc) {
+    let elem = doc.querySelector(targetCSSClassName);
+
+    reactCompile(elem, event.srcElement.value);
+  }
+
+
+  // Bind React and other public methods to the window object
+  WIN.React = React;
+  WIN._secretReactRenderMethod = ReactDOM.render;
+  WIN.onChangeLiveEditReact = onChangeLiveEditReact; //: debounce(onChangeLiveEditReact, 200);
+  WIN.reactCompile = reactCompile;
+
+  return {
+    onChangeLiveEditReact,
+    reactCompile,
+    debounce
+  };
+}

--- a/src/bootstrap/react.bootstrap.js
+++ b/src/bootstrap/react.bootstrap.js
@@ -1,17 +1,18 @@
 // Functions required by the host project to support live editing of components for React
 // This file should be imported by the host project's <framework>.bootstrap file
 
-import React from 'react';                                // Assume React and ReactDOM are included by host project
+// Assume React and ReactDOM are included by host project
+import React from 'react';
 import ReactDOM from 'react-dom';
 import debounce from 'javascript-debounce';
-const babel = require('babel-standalone/babel.min');      // This is needed to parse the <script type="text/babel"> blocks
+const babel = require('babel-standalone/babel.min');      // Import does not work with this module! This is needed to parse the <script type="text/babel"> blocks
 
 
 /*
  * @param dependentModulesArr   Format: {ComponentName: function ComponentName(...) {}, DatePicker: function DatePicker()...}
  */
 export default function(dependentModulesMap) {
-  const WIN = window; // eslint-disable-line
+  const WIN = window;
 
   // Export the default-export of each module onto the WINDOW object.
   // E.g.: window.DatePicker = function() ...
@@ -25,7 +26,7 @@ export default function(dependentModulesMap) {
     let result = babel.transform(`_secretReactRenderMethod(${newContent}, elem);`, {presets: ['es2015', 'react']});
 
     // Strangely, Babel doesn't eval the code automatically
-    eval(result.code);            // eslint-disable-line
+    eval(result.code);
   }
 
 

--- a/src/tag-defs/__tests__/area.test.js
+++ b/src/tag-defs/__tests__/area.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const areaTag = require('../area')();
 
 describe('area tag-def', () => {

--- a/src/tag-defs/__tests__/area.test.js
+++ b/src/tag-defs/__tests__/area.test.js
@@ -1,0 +1,46 @@
+const areaTag = require('../area')();
+
+describe('area tag-def', () => {
+
+  it('should return an object with a "name"<string> and "defaultFn"<function>', () => {
+    expect(areaTag.name).toEqual('area');
+    expect(typeof areaTag.defaultFn).toEqual('function');
+  });
+
+  describe('defaultFn', () => {
+
+    it('should return "api" when the file extension is "js"', () => {
+      let doc = {
+        fileInfo: {
+          extension: 'js',
+          relativePath: 'foo/bar/file'
+        }
+      };
+
+      expect(areaTag.defaultFn(doc)).toEqual('api');
+    });
+
+    it('should return "api" when the file extension is "jsx"', () => {
+      let doc = {
+        fileInfo: {
+          extension: 'jsx',
+          relativePath: 'foo/bar/file'
+        }
+      };
+
+      expect(areaTag.defaultFn(doc)).toEqual('api');
+    });
+
+    it('should return a substring of the relative path when the file extension is not "js" or "jsx"', () => {
+      let doc = {
+        fileInfo: {
+          extension: 'notjsorjsx',
+          relativePath: 'firstPartOfRelativePath/bar/file'
+        }
+      };
+
+      expect(areaTag.defaultFn(doc)).toEqual('firstPartOfRelativePath');
+    });
+  });
+
+});

--- a/src/tag-defs/area.js
+++ b/src/tag-defs/area.js
@@ -1,0 +1,12 @@
+module.exports = function() {
+  return {
+    name: 'area',
+    defaultFn: function(doc) {
+      let apiExtensions = ['js', 'jsx'];
+
+      // Code files are put in the 'api' area
+      // Other files compute their area from the first path segment
+      return apiExtensions.indexOf(doc.fileInfo.extension) > -1 ? 'api' : doc.fileInfo.relativePath.split('/')[0];
+    }
+  };
+};

--- a/src/tag-defs/area.js
+++ b/src/tag-defs/area.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function() {
   return {
     name: 'area',

--- a/src/tag-defs/index.js
+++ b/src/tag-defs/index.js
@@ -1,0 +1,3 @@
+module.exports = [
+  require('./area'),
+];

--- a/src/tag-defs/index.js
+++ b/src/tag-defs/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = [
   require('./area'),
 ];

--- a/src/templates/api/api.template.html
+++ b/src/templates/api/api.template.html
@@ -1,3 +1,4 @@
+{% import "lib/macros.html" as lib -%}
 {% extends "base.template.html" %}
 
 {% block content %}
@@ -43,9 +44,10 @@
     {%- if doc.examples %}
       <h4 class="{$ styles.h4 $}">Example</h4>
       {%- for example in doc.examples -%}
-        <div class="{$ styles['code-preview'] $} component-example-{$ doc.aliases[0] $}">
+        <div class="{$ styles['code-preview'] $} component-example-{$ doc.aliases[0] + loop.index $}">
           {$ example | marked $}
         </div>
+        {$ lib.liveEdit('onChangeLiveEditAngular', 'component-example-' + doc.aliases[0] + loop.index, example) $}
       {%- endfor -%}
     {% endif -%}
   {% endblock %}

--- a/src/templates/api/directive.template.html
+++ b/src/templates/api/directive.template.html
@@ -5,17 +5,7 @@
   {% block usage %}
     <div class="{$ styles['code-snippet'] $}">
       {% if doc.usage %}
-        <h4 class="{$ styles.h4 $}">Code Example</h4>
-        <div class="{$ styles['window-bar'] $} sd-accordion">
-          <div class="{$ styles.circles $}">
-            <span class="{$ styles.circle $} {$ styles['circle-red'] $}"></span>
-            <span class="{$ styles.circle $} {$ styles['circle-yellow'] $}"></span>
-            <span class="{$ styles.circle $} {$ styles['circle-green'] $}"></span>
-          </div>
-        </div>
-        <div class="{$ styles['code-wrapper'] $} sd-panel">
-          {$ doc.usage | marked $}
-        </div>
+        {% include "lib/usage.template.html" %}
       {% else %}
         <ul class="{$ styles.ul $}">
           {% if doc.restrict.element %}

--- a/src/templates/api/react.component.template.html
+++ b/src/templates/api/react.component.template.html
@@ -1,0 +1,32 @@
+{% extends "api/api.template.html" %}
+
+{# Override the api.template.html's "examples" template #}
+{% block examples %}
+  {%- if doc.examples %}
+    <h4 class="{$ styles.h4 $}">Example</h4>
+    {%- for example in doc.examples -%}
+      <div class="{$ styles['code-preview'] $} component-example-{$ doc.aliases[0] + loop.index $}"></div>
+      <script>
+        window.addEventListener('load', () => {
+          reactCompile(document.querySelector('.component-example-{$ doc.aliases[0] + loop.index $}'), `{$ example | marked $}`);
+        });
+      </script>
+      {$ lib.liveEdit('onChangeLiveEditReact', 'component-example-' + doc.aliases[0] + loop.index, example) $}
+    {%- endfor -%}
+  {% endif -%}
+{% endblock %}
+
+{# Remove the Angular-centric things  #}
+{% block additional %}
+  {% block usage %}
+    <div class="{$ styles['code-snippet'] $}">
+      {% if doc.usage %}
+        {% include "lib/usage.template.html" %}
+      {%- endif %}
+    </div>
+  {% endblock -%}
+
+  {% include "lib/params.template.html" %}
+  {% include "lib/events.template.html" %}
+{% endblock %}
+

--- a/src/templates/lib/macros.html
+++ b/src/templates/lib/macros.html
@@ -58,3 +58,9 @@
   </tr>
 </table>
 {%- endmacro -%}
+
+{%- macro liveEdit(onChangeFn, outputElementCSSClassName, content) %}
+<textarea style="width: 100%" rows="10" oninput="{$ onChangeFn $}(event, '.{$ outputElementCSSClassName $}', document)">
+  {$ content $}
+</textarea>
+{% endmacro -%}

--- a/src/templates/lib/macros.html
+++ b/src/templates/lib/macros.html
@@ -60,7 +60,12 @@
 {%- endmacro -%}
 
 {%- macro liveEdit(onChangeFn, outputElementCSSClassName, content) %}
-<textarea style="width: 100%" rows="10" oninput="{$ onChangeFn $}(event, '.{$ outputElementCSSClassName $}', document)">
+<textarea id="{$ outputElementCSSClassName $}_editor" style="width: 100%; display:none" rows="10" oninput="{$ onChangeFn $}(event, '.{$ outputElementCSSClassName $}', document)">
   {$ content $}
 </textarea>
+<script> window.addEventListener('load', () => {
+  if ({$ onChangeFn $}) {
+    document.querySelector('#{$ outputElementCSSClassName $}_editor').style.display = 'block';
+  }
+});</script>
 {% endmacro -%}

--- a/src/templates/lib/usage.template.html
+++ b/src/templates/lib/usage.template.html
@@ -1,0 +1,11 @@
+<h4 class="{$ styles.h4 $}">Code Example</h4>
+<div class="{$ styles['window-bar'] $} sd-accordion">
+  <div class="{$ styles.circles $}">
+    <span class="{$ styles.circle $} {$ styles['circle-red'] $}"></span>
+    <span class="{$ styles.circle $} {$ styles['circle-yellow'] $}"></span>
+    <span class="{$ styles.circle $} {$ styles['circle-green'] $}"></span>
+  </div>
+</div>
+<div class="{$ styles['code-wrapper'] $} sd-panel">
+  {$ doc.usage | marked $}
+</div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -984,9 +984,9 @@ dezalgo@^1.0.1:
     asap "^2.0.0"
     wrappy "1"
 
-"dgeni-packages@git://github.com/angular/dgeni-packages":
-  version "0.16.0"
-  resolved "git://github.com/angular/dgeni-packages#96cb8139e8876150b5a6ce08f2c5eef7fbd791f6"
+dgeni-packages@0.16.1:
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/dgeni-packages/-/dgeni-packages-0.16.1.tgz#bf63d52f62ca39760db3a789772d0a7ce2b55a2e"
   dependencies:
     canonical-path "0.0.2"
     catharsis "^0.8.1"
@@ -2126,11 +2126,15 @@ istanbul@0.4.5, istanbul@^0.4.5:
     which "^1.1.1"
     wordwrap "^1.0.0"
 
+javascript-debounce@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/javascript-debounce/-/javascript-debounce-1.0.0.tgz#6c7fc8485e73faa422fe5a96351edb257fb0a400"
+
 jest-changed-files@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-17.0.2.tgz#f5657758736996f590a51b87e5c9369d904ba7b7"
 
-jest-cli@^17.0.3:
+jest-cli@17.0.3:
   version "17.0.3"
   resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-17.0.3.tgz#700b8c02a9ea0ec9eab0cd5a9fd42d8a858ce146"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -386,6 +386,10 @@ babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.20.0, babel-runtim
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
+babel-standalone@6.23.1:
+  version "6.23.1"
+  resolved "https://registry.yarnpkg.com/babel-standalone/-/babel-standalone-6.23.1.tgz#904a6db801f6b485e693459e8adc6c3a00416e20"
+
 babel-template@^6.16.0:
   version "6.16.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.16.0.tgz#e149dd1a9f03a35f817ddbc4d0481988e7ebc8ca"
@@ -1202,6 +1206,16 @@ eslint-config-defaults@9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/eslint-config-defaults/-/eslint-config-defaults-9.0.0.tgz#a090adc13b2935e3f43b3cd048a92701654e5ad5"
 
+eslint-plugin-node@4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-4.2.1.tgz#52e8e06595d0be63a25fdc237be5e42b69a46eaa"
+  dependencies:
+    ignore "^3.0.11"
+    minimatch "^3.0.2"
+    object-assign "^4.0.1"
+    resolve "^1.1.7"
+    semver "5.3.0"
+
 eslint@3.12.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.12.0.tgz#1dfa4ef0082e35feed90a0fb1f7996d1d426b249"
@@ -1800,7 +1814,7 @@ iconv-lite@^0.4.13:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 
-ignore@^3.2.0:
+ignore@^3.0.11, ignore@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.2.0.tgz#8d88f03c3002a0ac52114db25d2c673b0bf1e435"
 
@@ -3429,7 +3443,7 @@ resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
-resolve@1.1.7, resolve@1.1.x, resolve@^1.1.6:
+resolve@1.1.7, resolve@1.1.x, resolve@^1.1.6, resolve@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
@@ -3536,7 +3550,7 @@ semver-regex@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-1.0.0.tgz#92a4969065f9c70c694753d55248fc68f8f652c9"
 
-"semver@2 >=2.2.1 || 3.x || 4 || 5", "semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.2.0, semver@^5.3.0, semver@~5.3.0:
+"semver@2 >=2.2.1 || 3.x || 4 || 5", "semver@2 || 3 || 4 || 5", semver@5.3.0, semver@^5.0.3, semver@^5.1.0, semver@^5.2.0, semver@^5.3.0, semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 


### PR DESCRIPTION
~~Requires changes to the angular.bootstrap.js file generated by the "swanky" package by default. I'll make those changes next~~

I've prepared a change to guide.swanky-docs.org which describes how to add support for live-editing of examples. I'll also make changes to patterns.swanky-docs.org to enable the live editing function. But that relies on **this** PR going through.