### PR TITLE
feat(app): add syntax highlighting to live edit region

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "babel-standalone": "6.23.1",
+    "codemirror": "5.25.0",
     "dgeni": "0.4.2",
     "dgeni-packages": "0.16.1",
     "ejs": "2.5.5",

--- a/src/bootstrap/angular.bootstrap.js
+++ b/src/bootstrap/angular.bootstrap.js
@@ -6,6 +6,11 @@
 const angular = require('angular');
 const debounce = require('javascript-debounce');
 
+// Code Editor
+const CodeMirror = require ('codemirror/lib/codemirror');
+require('codemirror/lib/codemirror.css');
+require('codemirror/mode/javascript/javascript.js');
+
 const ROOT_MOD_NAME = 'swanky$$ModuleRoot';
 
 /*
@@ -37,14 +42,28 @@ module.exports = function(dependentModulesMap) {
     }]);
   }
 
-  function onChangeLiveEditAngular(event, targetCSSClassName, doc) {
-    var elem = doc.querySelector(targetCSSClassName);
-
-    angularCompile(elem, event.srcElement.value);
+  function onChangeLiveEditAngular(target, value) {
+    angularCompile(target, value);
   }
 
-  window.onChangeLiveEditAngular = onChangeLiveEditAngular;
-  // debounce(onChangeLiveEditAngular, 200);
+  // Create a new Code Mirror instance for each editor
+  const liveEditors = document.getElementsByClassName('live-editor');
+
+  for (var i = 0; i < liveEditors.length; i++) {
+    (function(index) {
+      var editor = liveEditors[index];
+
+      CodeMirror.fromTextArea(editor, {
+        lineNumbers: true,
+        lineWrapping: true,
+        mode: "htmlmixed"
+      }).on('change', function (codeMirror) {
+        var outputEl = document.getElementsByClassName(editor.dataset.output)[0];
+
+        onChangeLiveEditAngular(outputEl, codeMirror.getValue());
+      });
+    })(i);
+  }
 
   return {
     onChangeLiveEditAngular: onChangeLiveEditAngular,

--- a/src/bootstrap/react.bootstrap.js
+++ b/src/bootstrap/react.bootstrap.js
@@ -8,17 +8,21 @@ const React = require('react');
 const ReactDOM = require('react-dom');
 const debounce = require('javascript-debounce');
 
+// Code Editor
+const CodeMirror = require('codemirror/lib/codemirror');
+require('codemirror/lib/codemirror.css');
+require('codemirror/mode/javascript/javascript.js');
 
 /*
  * @param dependentModulesArr   Format: {ComponentName: function ComponentName(...) {}, DatePicker: function DatePicker()...}
  */
-module.exports = function(dependentModulesMap) {
+module.exports = function (dependentModulesMap) {
   const WIN = window;
 
   // Export the default-export of each module onto the WINDOW object.
   // E.g.: window.DatePicker = function() ...
   // This allows Babel to compile JSX references to the component correctly. E.g. ReactDOM.render(<DatePicker id="..."/> works)
-  Object.keys(dependentModulesMap).forEach(function(moduleKey) {
+  Object.keys(dependentModulesMap).forEach(function (moduleKey) {
     WIN[moduleKey] = dependentModulesMap[moduleKey];
   });
 
@@ -27,25 +31,53 @@ module.exports = function(dependentModulesMap) {
     elem.textContent = '';  // Clear the existing content
 
     // Babel is defined in the React live-update template via an external script
-    var result = Babel.transform('_secretReactRenderMethod(' + newContent + ', elem);', { presets: ['es2015', 'react'] });
+    var result;
+
+    try {
+      result = Babel.transform('_secretReactRenderMethod(' + newContent + ', elem);', { presets: ['es2015', 'react'] });
+    } catch (err) {
+      console.log(err);
+    }
 
     // Strangely, Babel doesn't eval the code automatically
-    eval(result.code);
+    if (result) {
+      eval(result.code);
+    }
   }
 
 
-  function onChangeLiveEditReact(event, targetCSSClassName, doc) {
-    var elem = doc.querySelector(targetCSSClassName);
-
-    reactCompile(elem, event.srcElement.value);
+  function onChangeLiveEditReact(element, value) {
+    reactCompile(element, value);
   }
 
 
   // Bind React and other public methods to the window object
   WIN.React = React;
   WIN._secretReactRenderMethod = ReactDOM.render;
-  WIN.onChangeLiveEditReact = onChangeLiveEditReact; //: debounce(onChangeLiveEditReact, 200);
-  WIN.reactCompile = reactCompile;
+
+  // Create a new Code Mirror instance for each editor
+  const liveEditors = document.getElementsByClassName('live-editor');
+
+  for (var i = 0; i < liveEditors.length; i++) {
+    (function (index) {
+      var editor = liveEditors[index];
+
+      var codeMirrorInstance = CodeMirror.fromTextArea(editor, {
+        lineNumbers: true,
+        lineWrapping: true,
+        mode: "htmlmixed"
+      })
+
+      var outputEl = document.getElementsByClassName(editor.dataset.output)[0];
+
+      codeMirrorInstance.on('change', function (codeMirror) {
+        onChangeLiveEditReact(outputEl, codeMirror.getValue());
+      });
+
+      // Init
+      onChangeLiveEditReact(outputEl, codeMirrorInstance.getValue());
+    })(i);
+  }
 
   return {
     onChangeLiveEditReact: onChangeLiveEditReact,

--- a/src/templates/api/api.template.html
+++ b/src/templates/api/api.template.html
@@ -4,9 +4,9 @@
 {% block content %}
 
   {% block header %}
-  <header class="api-profile-header">
-    <h4 class="{$ styles.h4 $}"><strong>name:</strong> <code class="{$ styles.code $}">{$ doc.name $}</code></h4>
-  </header>
+    <header class="api-profile-header">
+      <h4 class="{$ styles.h4 $}"><strong>name:</strong> <code class="{$ styles.code $}">{$ doc.name $}</code></h4>
+    </header>
   {% endblock %}
 
   {% block description %}
@@ -25,17 +25,18 @@
   {% endif %}
 
   {% if doc.deprecated %}
-  <fieldset class="{$ styles.deprecated $}">
-    <legend class="{$ styles.legend $}">Deprecated API</legend>
-    {$ doc.deprecated| marked $}
-  </fieldset>
+    <fieldset class="{$ styles.deprecated $}">
+      <legend class="{$ styles.legend $}">Deprecated API</legend>
+      {$ doc.deprecated| marked $}
+    </fieldset>
   {% endif %}
 
   {% block dependencies %}
     {%- if doc.requires %}
       <h4 class="{$ styles.h4 $}">Dependencies</h4>
       <ul class="{$ styles.ul $}">
-        {% for require in doc.requires %}<li class="{$ styles.li $}">{$ require | link $}</li>{% endfor %}
+        {% for require in doc.requires %}
+          <li class="{$ styles.li $}">{$ require | link $}</li>{% endfor %}
       </ul>
     {% endif -%}
   {% endblock %}

--- a/src/templates/api/react.component.template.html
+++ b/src/templates/api/react.component.template.html
@@ -7,12 +7,7 @@
     {%- for example in doc.examples -%}
       <div class="{$ styles['code-preview'] $} component-example-{$ doc.aliases[0] + loop.index $}"></div>
       <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
-      <script>
-        window.addEventListener('load', () => {
-          reactCompile(document.querySelector('.component-example-{$ doc.aliases[0] + loop.index $}'), `{$ example | marked $}`);
-        });
-      </script>
-      {$ lib.liveEdit('onChangeLiveEditReact', 'component-example-' + doc.aliases[0] + loop.index, example) $}
+      {$ lib.liveEdit('onChangeLiveEditReact', 'component-example-' + doc.aliases[0] + loop.index, example, styles) $}
     {%- endfor -%}
   {% endif -%}
 {% endblock %}

--- a/src/templates/lib/macros.html
+++ b/src/templates/lib/macros.html
@@ -1,35 +1,38 @@
 {% macro typeList(types, styles) -%}
-{% for typeName in types %}<a href="" class="{$ typeName | typeClass $} {$ styles.a $}">{$ typeName | escape $}</a>{% endfor %}
+  {% for typeName in types %}<a href="" class="{$ typeName | typeClass $} {$ styles.a $}">{$ typeName | escape
+    $}</a>{% endfor %}
 {%- endmacro -%}
 
 {%- macro paramTable(params, styles) %}
-<table class="{$ styles.table $} {$ styles['variables-matrix'] $} {$ styles['input-arguments'] $}">
-  <thead class="{$ styles.thead $}">
+  <table class="{$ styles.table $} {$ styles['variables-matrix'] $} {$ styles['input-arguments'] $}">
+    <thead class="{$ styles.thead $}">
     <tr class="{$ styles.tr $}">
       <th class="{$ styles.th $}">Param</th>
       <th class="{$ styles.th $}">Type</th>
       <th class="{$ styles.th $}">Details</th>
     </tr>
-  </thead>
-  <tbody class="{$ styles.thbody $}">
+    </thead>
+    <tbody class="{$ styles.thbody $}">
     {% for param in params %}
-    <tr class="{$ styles.tr $}">
-      <td class="{$ styles.td $}">
-        {$ param.name $}
-        {% if param.alias %}| {$ param.alias $}{% endif %}
-        {% if param.optional %}<div><em class="{$ styles.em $}">(optional)</em></div>{% endif %}
-      </td>
-      <td class="{$ styles.td $}">
-        {$ typeList(param.typeList, styles) $}
-      </td>
-      <td class="{$ styles.td $}">
-        {$ param.description | marked $}
-        {% if param.defaultValue %}<p><em>(default: {$ param.defaultValue $})</em></p>{% endif %}
-      </td>
-    </tr>
+      <tr class="{$ styles.tr $}">
+        <td class="{$ styles.td $}">
+          {$ param.name $}
+          {% if param.alias %}| {$ param.alias $}{% endif %}
+          {% if param.optional %}
+            <div><em class="{$ styles.em $}">(optional)</em></div>
+          {% endif %}
+        </td>
+        <td class="{$ styles.td $}">
+          {$ typeList(param.typeList, styles) $}
+        </td>
+        <td class="{$ styles.td $}">
+          {$ param.description | marked $}
+          {% if param.defaultValue %}<p><em>(default: {$ param.defaultValue $})</em></p>{% endif %}
+        </td>
+      </tr>
     {% endfor %}
-  </tbody>
-</table>
+    </tbody>
+  </table>
 {% endmacro -%}
 
 
@@ -42,30 +45,29 @@
 {%- macro functionSyntax(fn) %}
   {%- set sep = joiner(', ') -%}
   {% marked -%}
-    `{$ fn.name $}({%- for param in fn.params %}{$ sep() $}
-    {%- if param.type.optional %}[{% endif -%}
-    {$ param.name $}
-    {%- if param.type.optional %}]{% endif -%}
-    {% endfor %});`
+  `{$ fn.name $}({%- for param in fn.params %}{$ sep() $}
+  {%- if param.type.optional %}[{% endif -%}
+  {$ param.name $}
+  {%- if param.type.optional %}]{% endif -%}
+{% endfor %});`
   {%- endmarked %}
 {% endmacro -%}
 
 {%- macro typeInfo(fn, styles) -%}
-<table class="{$ styles.table $} {$ styles['variables-matrix'] $} {$ styles['return-arguments'] $}">
-  <tr class="{$ styles.tr $}">
-    <td class="{$ styles.td $}">{$ typeList(fn.typeList, styles) $}</td>
-    <td class="{$ styles.td $}">{$ fn.description | marked $}</td>
-  </tr>
-</table>
+  <table class="{$ styles.table $} {$ styles['variables-matrix'] $} {$ styles['return-arguments'] $}">
+    <tr class="{$ styles.tr $}">
+      <td class="{$ styles.td $}">{$ typeList(fn.typeList, styles) $}</td>
+      <td class="{$ styles.td $}">{$ fn.description | marked $}</td>
+    </tr>
+  </table>
 {%- endmacro -%}
 
-{%- macro liveEdit(onChangeFn, outputElementCSSClassName, content) %}
-<textarea id="{$ outputElementCSSClassName $}_editor" style="width: 100%; display:none" rows="10" oninput="{$ onChangeFn $}(event, '.{$ outputElementCSSClassName $}', document)">
+{%- macro liveEdit(onChangeFn, outputElementCSSClassName, content, styles) %}
+  <h4 class="{$ styles.h4 $}">Live Edit</h4>
+
+  <textarea id="{$ outputElementCSSClassName $}_editor" data-output="{$ outputElementCSSClassName $}"
+            class="live-editor"
+            style="display:none" rows="10">
   {$ content $}
 </textarea>
-<script> window.addEventListener('load', () => {
-  if ({$ onChangeFn $}) {
-    document.querySelector('#{$ outputElementCSSClassName $}_editor').style.display = 'block';
-  }
-});</script>
 {% endmacro -%}

--- a/yarn.lock
+++ b/yarn.lock
@@ -715,6 +715,10 @@ codecov.io@0.1.6:
     request "2.42.0"
     urlgrey "0.4.0"
 
+codemirror@^5.25.0:
+  version "5.25.0"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.25.0.tgz#78e06939c7bb41f65707b8aa9c5328111948b756"
+
 collections@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/collections/-/collections-0.2.2.tgz#1f23026b2ef36f927eecc901e99c5f0d48fa334e"


### PR DESCRIPTION
@uglow I have integrated `CodeMirror` for syntax highlighting and formatting for live edit regions. Please take a look. Styling will come in next code push.

Also - when you include the latest `swanky` you now need to import `react` regardles of whether you are using it or not. Any suggestions on how we can prevent having to require this dep if not required?